### PR TITLE
Update version of workflow actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,8 @@ jobs:
       image: bilelmoussaoui/flatpak-github-actions:gnome-43
       options: --privileged
     steps:
-    - uses: actions/checkout@v2
-    - uses: flatpak/flatpak-github-actions/flatpak-builder@v4
+    - uses: actions/checkout@v3
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@v5
       with:
         bundle: devtoolbox-devel.flatpak
         manifest-path: me.iepure.devtoolbox.json


### PR DESCRIPTION
Solve "Node.js 12 actions are deprecated" warning.

Message:
> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, flatpak/flatpak-github-actions/flatpak-builder@v4. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
