### PR TITLE
Update temp file cleanup logic to remove specific files

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@
 
 import sys
 import gi
+from pathlib import Path
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
@@ -117,8 +118,10 @@ class DevtoolboxApplication(Adw.Application):
 
     def on_quit_action(self, widget, _):
         # Clean up temp files
-        shutil.rmtree(GLib.get_tmp_dir(), ignore_errors=True)
         
+        tmp_files =  Path(GLib.get_tmp_dir()).glob('me.iepure.devtoolbox*')
+        for tmp_file in tmp_files:
+            tmp_file.unlink(missing_ok=True)
         self.quit()
 
     def create_action(self, name, callback, shortcuts=None):


### PR DESCRIPTION
For the people that don't want to use flatpack based packages and thus the sand-boxing that comes with it (like arch linux users), the cleanup logic on the `on_quit_action` function would remove their whole tmp folder. This could cause other process that relies on the tmp folder to crash. This can easily be fixed with the existing prefix on tmp file.