### PR TITLE
Support for advanced YAML types in Yaml to JSON conversion

### DIFF
--- a/src/services/json_yaml.py
+++ b/src/services/json_yaml.py
@@ -7,6 +7,18 @@ from gi.repository import Gio, GObject
 import ruamel.yaml
 import json
 
+import datetime
+
+class ExtendedJSONEncoder(json.JSONEncoder):
+
+    def default(self, value):
+        if isinstance(value, datetime.datetime):
+            return value.timestamp()
+        if isinstance(value, datetime.date):
+            return value.strftime("%Y-%m-%d")
+        if isinstance(value, ruamel.yaml.comments.CommentedSet):
+            return list(value)
+        return super().default(value)
 
 class JsonYamlService():
 
@@ -34,10 +46,12 @@ class JsonYamlService():
 
     def _convert_yaml_to_json(self, yaml_str:str, indents:int) -> str:
         yaml = ruamel.yaml.YAML(typ='rt')
+
         return json.dumps(
             yaml.load(yaml_str),
             indent=indents,
-            ensure_ascii=False
+            ensure_ascii=False,
+            cls=ExtendedJSONEncoder,
         )
 
     def convert_json_to_yaml_async(self, caller:GObject.Object, callback:callable):


### PR DESCRIPTION
Hello! I noticed the tool cannot handle dates and timestamps in YAML to JSON conversion, as those types don't have direct equivalents in JSON, and python's JSONEncoder raises an exception when they are present in an input data.

I implemented a solution, that converts those types to useful equivalents:
- dates (ex. `2000-01-01`) are converted to python's `datetime.date` and then to JSON strings
- timestamps (ex. `2001-01-01 12:00:00`) are converted to python's `datetime.datetime` and then to JSON number, representing Unix timestamp. This is important, as the YAML timestamp can optionally contain timezone information.
- YAML sets (`!!set`) are converted to custom class of `ruamel.yaml` lib, and then to JSON arrays.
