### PR TITLE
Color Converter: Fix default visibility of angle ComboRow

### DIFF
--- a/src/ui/views/color_converter.blp
+++ b/src/ui/views/color_converter.blp
@@ -46,6 +46,7 @@ template $ColorConverterView: Adw.Bin {
               title: _("Angle Unit");
               subtitle: _("Unit used for angle component");
               icon-name: "timer";
+              visible: false;
 
               model: StringList {
                 strings [


### PR DESCRIPTION
Missed this during the refactor to ComboRow from ToggleGroup.
Caused the angle unit selector to be incorrectly shown on the web views on first startup.