### PR TITLE
SpinArea: increase precision of get_value

### DIFF
--- a/src/ui/widgets/spin_area.blp
+++ b/src/ui/widgets/spin_area.blp
@@ -100,7 +100,7 @@ template $SpinArea: Adw.Bin {
 
         adjustment: Adjustment {
           lower: 0;
-          upper: 99999999999;
+          upper: 9000000000000000;
           step-increment: 1;
         };
       }

--- a/src/widgets/spin_area.py
+++ b/src/widgets/spin_area.py
@@ -62,7 +62,7 @@ class SpinArea(Adw.Bin):
         self.emit("action-clicked")
 
     def _on_copy_clicked(self, user_data:GObject.GPointer):
-        text      = str(self._spin_btn.get_value_as_int())
+        text      = str(int(self._spin_btn.get_value()))
         clipboard = Gdk.Display.get_clipboard(Gdk.Display.get_default())
         clipboard.set(text)
 
@@ -87,7 +87,7 @@ class SpinArea(Adw.Bin):
         self.emit("value-changed")
 
     def get_value(self) -> int:
-        return self._spin_btn.get_value_as_int()
+        return int(self._spin_btn.get_value())
 
     def set_value(self, value:int):
         self._spin_btn.set_value(value)


### PR DESCRIPTION
This is somewhat in relation to the already closed #65.

Currently the timestamp SpinArea widget in the timestamp tool is limited to int32, thus not working for any dates with year 2038 or higher.
The SpinButton widget that is used inside SpinArea natively uses a double, this workaround converts the double value into pythons native bigint, instead of using the int32 getter from the widget. This results in effective 53 bits of integer precision instead of 31 from int32, allowing for larger values to be input.
