### PR TITLE
Fix appdata paper cuts

### DIFF
--- a/data/me.iepure.devtoolbox.metainfo.xml.in
+++ b/data/me.iepure.devtoolbox.metainfo.xml.in
@@ -164,8 +164,9 @@ SPDX-License-Identifier: CC0-1.0
           <li>Timestamp: More timezones to choose from</li>
           <li>Timestamp: Time and date are now displayed in more formats</li>
           <li>Updated dependencies and platform version to GNOME 47</li>
-        </ul> Thank you for
-        the new and updated translations via weblate. </description>
+        </ul>
+        <p>Thank you for the new and updated translations via weblate.</p>
+      </description>
     </release>
     <release version="1.1.1" date="2023-06-18">
       <description translate="no">


### PR DESCRIPTION
Fix the following error

> Error: Appstream: 'E:me.iepure.devtoolbox.metainfo.xml:description-spurious-text:352 
> The description element contains raw text that is not in any paragraph or other permitted tag. This is not allowed and the additional text may be ignored by parsers or raise errors.'