### PR TITLE
Fix typo in French translation for 'Symmetric'

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -2281,7 +2281,7 @@ msgstr "Off"
 
 #: src/ui/views/jwt_decoder.blp:46
 msgid "Symmetric"
-msgstr "Symmétrique"
+msgstr "Symétrique"
 
 #: src/ui/views/jwt_decoder.blp:51
 msgid "Asymmetric"


### PR DESCRIPTION
See:
- https://dictionnaire.lerobert.com/definition/symetrique